### PR TITLE
Thaumcraft Scripts

### DIFF
--- a/scripts/TC4 - Aspects - BinniesMods.zs
+++ b/scripts/TC4 - Aspects - BinniesMods.zs
@@ -1,0 +1,454 @@
+print("Initializing 'Thaumcraft-Aspects-Binnies.zs'...");
+
+
+
+### Forestry ###
+# Author: daforsyth
+
+# Backpacks
+mods.thaumcraft.Aspects.set(<Forestry:minerBag>, "pannus 6, vacuos 4, metallum 4, perfodio 4");
+mods.thaumcraft.Aspects.set(<Forestry:hunterBag>, "pannus 6, vacuos 4, metallum 4, bestia 4");
+mods.thaumcraft.Aspects.set(<Forestry:adventurerBag>, "pannus 6, vacuos 4, metallum 4, iter 4");
+mods.thaumcraft.Aspects.set(<Forestry:foresterBag>, "pannus 6, vacuos 4, metallum 4, herba 4");
+mods.thaumcraft.Aspects.set(<Forestry:diggerBag>, "pannus 6, vacuos 4, metallum 4, terra 4");
+mods.thaumcraft.Aspects.set(<Forestry:coinBag>, "pannus 6, vacuos 4, metallum 4, lucrum 4");
+mods.thaumcraft.Aspects.set(<Forestry:builderBag>, "pannus 6, vacuos 4, metallum 4, ordo 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:minerBagT2>, "pannus 12, vacuos 6, metallum 4, perfodio 4");
+mods.thaumcraft.Aspects.set(<Forestry:hunterBagT2>, "pannus 12, vacuos 6, metallum 4, bestia 4");
+mods.thaumcraft.Aspects.set(<Forestry:adventurerBagT2>, "pannus 12, vacuos 6, metallum 4, iter 4");
+mods.thaumcraft.Aspects.set(<Forestry:foresterBagT2>, "pannus 12, vacuos 6, metallum 4, herba 4");
+mods.thaumcraft.Aspects.set(<Forestry:diggerBagT2>, "pannus 12, vacuos 6, metallum 4, terra 4");
+mods.thaumcraft.Aspects.set(<Forestry:coinBagT2>, "pannus 12, vacuos 6, metallum 4, lucrum 4");
+mods.thaumcraft.Aspects.set(<Forestry:builderBagT2>, "pannus 12, vacuos 6, metallum 4, ordo 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:apiaristBag>, "pannus 6, vacuos 6, metallum 4, bestia 4, volatus 4");
+mods.thaumcraft.Aspects.set(<Forestry:lepidopteristBag>, "pannus 6, vacuos 6, metallum 4, bestia 4, volatus 4");
+
+# Electron Tubes
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes>, "vitreus 1, machina 1, metallum 1, permutatio 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:1>, "vitreus 2, machina 1, metallum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:2>, "vitreus 1, machina 1, metallum 1, instrumentum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:3>, "vitreus 1, machina 1, metallum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:4>, "vitreus 1, machina 1, metallum 1, lucrum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:5>, "vitreus 2, machina 1, lucrum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:6>, "vitreus 1, machina 1, terra 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:11>, "vitreus 1, machina 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:12>, "vitreus 1, machina 1, alienis 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:13>, "vitreus 1, machina 1, venenum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:10>, "vitreus 1, machina 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:9>, "vitreus 2, machina 1, lucrum 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:8>, "vitreus 1, machina 1, limus 1");
+mods.thaumcraft.Aspects.set(<Forestry:thermionicTubes:7>, "vitreus 1, machina 1, ignis 1");
+
+# Machine Parts
+mods.thaumcraft.Aspects.set(<Forestry:gearTin>, "metallum 19, vitreus 5, machina 2");
+mods.thaumcraft.Aspects.set(<Forestry:gearCopper>, "metallum 19, permutatio 5, machina 2");
+mods.thaumcraft.Aspects.set(<Forestry:gearBronze>, "metallum 19, fabrico 5, instrumentum 3, machina 2");
+
+mods.thaumcraft.Aspects.set(<Forestry:hardenedMachine>, "metallum 36, instrumentum 6, fabrico 6, vitreus 12, lucrum 12");
+mods.thaumcraft.Aspects.set(<Forestry:impregnatedCasing>, "arbor 24, fabrico 4");
+
+# Matierals
+mods.thaumcraft.Aspects.set(<Forestry:ash>, "perditio 1, permutatio 1");
+mods.thaumcraft.Aspects.set(<Forestry:peat>, "ignis 3, potentia 3, herba 3");
+mods.thaumcraft.Aspects.set(<Forestry:bituminousPeat>, "ignis 6, potentia 6, herba 6");
+mods.thaumcraft.Aspects.set(<Forestry:craftingMaterial:2>, "pannus 1");
+mods.thaumcraft.Aspects.set(<Forestry:craftingMaterial:3>, "pannus 6, fabrico 2");
+mods.thaumcraft.Aspects.set(<Forestry:woodPulp>, "arbor 1, aqua 1");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryWax>, "ordo 3");
+mods.thaumcraft.Aspects.set(<Forestry:craftingMaterial:5>, "gelum 3");
+
+# Tools
+mods.thaumcraft.Aspects.set(<Forestry:carton>, "arbor 1");
+mods.thaumcraft.Aspects.set(<Forestry:crate>, "arbor 1");
+mods.thaumcraft.Aspects.set(<Forestry:brokenBronzePickaxe>, "metallum 1, perditio 1, perfodio 1");
+mods.thaumcraft.Aspects.set(<Forestry:brokenBronzeShovel>, "metallum 1, perditio 1, instrumentum 1");
+mods.thaumcraft.Aspects.set(<Forestry:solderingIron>, "metallum 4, ignis 2, instrumentum 1");
+
+# Alveary
+mods.thaumcraft.Aspects.set(<Forestry:oakStick>, "arbor 1, herba 1");
+mods.thaumcraft.Aspects.set(<Forestry:craftingMaterial:6>, "arbor 3, ordo 2, fabrico 2");
+
+mods.thaumcraft.Aspects.set(<Forestry:alveary:7>, "arbor 4, vinculum 3, pannus 3, herba 2, fabrico 4");
+mods.thaumcraft.Aspects.set(<Forestry:alveary>, "arbor 4, ordo 4, fabrico 4");
+mods.thaumcraft.Aspects.set(<Forestry:alveary:2>, "arbor 4, luxuria 3, fabrico 4");
+mods.thaumcraft.Aspects.set(<Forestry:alveary:3>, "arbor 4, machina 3, aer 3, gelum 3, fabrico 4");
+mods.thaumcraft.Aspects.set(<Forestry:alveary:4>, "arbor 4, machina 3, ignis 3, fabrico 4");
+mods.thaumcraft.Aspects.set(<Forestry:alveary:5>, "arbor 4, machina 3, aqua 3, tempestas 1, fabrico 4");
+mods.thaumcraft.Aspects.set(<Forestry:alveary:6>, "arbor 4, fabrico 4, vitreus 6, ordo 4");
+
+# Mail
+mods.thaumcraft.Aspects.set(<Forestry:stamps>, "limus 0");
+mods.thaumcraft.Aspects.set(<Forestry:stamps:1>, "limus 0");
+mods.thaumcraft.Aspects.set(<Forestry:stamps:2>, "limus 0");
+mods.thaumcraft.Aspects.set(<Forestry:stamps:3>, "limus 0");
+
+mods.thaumcraft.Aspects.set(<Forestry:catalogue>, "cognitio 1");
+mods.thaumcraft.Aspects.set(<Forestry:letters>, "cognitio 1, limus 0");
+
+# Circuit Boards
+mods.thaumcraft.Aspects.set(<Forestry:chipsets>, "metallum 1, potentia 2, machina 1");
+mods.thaumcraft.Aspects.set(<Forestry:chipsets:1>, "metallum 3, potentia 2, machina 1, fabrico 2");
+mods.thaumcraft.Aspects.set(<Forestry:chipsets:2>, "metallum 6, potentia 2, machina 1");
+mods.thaumcraft.Aspects.set(<Forestry:chipsets:3>, "metallum 3, potentia 2, machina 1, lucrum 1");
+
+# Ore and Metal
+mods.thaumcraft.Aspects.set(<Forestry:resourceStorage:3>, "metallum 20, instrumentum 6");
+mods.thaumcraft.Aspects.set(<Forestry:resourceStorage:2>, "metallum 20, vitreus 6");
+mods.thaumcraft.Aspects.set(<Forestry:resourceStorage:1>, "metallum 20, permutatio 6");
+mods.thaumcraft.Aspects.set(<Forestry:resources>, "vitreus 3, terra 2");
+
+# Bees
+mods.thaumcraft.Aspects.set(<Forestry:core:1>, "arbor 5, cognitio 3");
+mods.thaumcraft.Aspects.set(<Forestry:beealyzer>, "machina 4, bestia 2, volatus 2, sensus 4");
+mods.thaumcraft.Aspects.set(<Forestry:propolis:1>, "limus 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:apiaristHelmet>, "pannus 12, fabrico 3, tutamen 1");
+mods.thaumcraft.Aspects.set(<Forestry:apiaristChest>, "pannus 20, fabrico 5, tutamen 3");
+mods.thaumcraft.Aspects.set(<Forestry:apiaristLegs>, "pannus 17, fabrico 4, tutamen 2");
+mods.thaumcraft.Aspects.set(<Forestry:apiaristBoots>, "pannus 10, fabrico 2, tutamen 1");
+
+mods.thaumcraft.Aspects.add(<Forestry:pollen:1>, "gelum 1");
+
+mods.thaumcraft.Aspects.set(<Forestry:frameUntreated>, "arbor 4, vinculum 1");
+mods.thaumcraft.Aspects.set(<Forestry:frameImpregnated>, "arbor 4, fabrico 2, vinculum 1");
+mods.thaumcraft.Aspects.set(<Forestry:frameProven>, "arbor 4, fabrico 4, vinculum 1");
+
+# Adding to combs
+mods.thaumcraft.Aspects.add(<Forestry:beeCombs:4>, "gelum 2");
+mods.thaumcraft.Aspects.add(<Forestry:beeCombs:15>, "herba 2");
+mods.thaumcraft.Aspects.add(<Forestry:beeCombs:6>, "pannus 1");
+mods.thaumcraft.Aspects.add(<Forestry:beeCombs:2>, "ignis 2");
+
+# Gross wheat
+mods.thaumcraft.Aspects.set(<Forestry:mouldyWheat>, "messis 2, aqua 1");
+mods.thaumcraft.Aspects.set(<Forestry:decayingWheat>, "messis 1, perditio 2");
+
+# Liquids
+mods.thaumcraft.Aspects.set(<Forestry:refractoryEmpty>, "fabrico 1");
+mods.thaumcraft.Aspects.set(<Forestry:beverage:2>, "aqua 1, vitreus 1, fames 4, venenum 2");
+mods.thaumcraft.Aspects.set(<Forestry:beverage>, "aqua 1, vitreus 1, fames 2, venenum 2");
+mods.thaumcraft.Aspects.set(<Forestry:beverage:1>, "aqua 1, vitreus 1, fames 2, sano 1");
+
+mods.thaumcraft.Aspects.set(<Forestry:craftingMaterial:4>, "aqua 1, lux 1, tempestas 3");
+mods.thaumcraft.Aspects.set(<Forestry:iodineCapsule>, "aqua 2, tempestas 3");
+mods.thaumcraft.Aspects.set(<Forestry:phosphoricIodineCapsule>, "aqua 2, tempestas 3");
+
+mods.thaumcraft.Aspects.set(<Forestry:bucketBiomass>, "metallum 8, aqua 2, herba 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketGlass>, "metallum 8, ignis 1, vitreus 3, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketEthanol>, "metallum 8, aqua 2, potentia 4, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketHoney>, "metallum 8, aqua 1, fames 3, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketIce>, "metallum 8, gelum 4, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketJuice>, "metallum 8, aqua 2, fames 2, messis 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketSeedOil>, "metallum 8, aqua 1, herba 3, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketShortMead>, "metallum 8, aqua 2, fames 4, venenum 4, vacuos 1");
+mods.thaumcraft.Aspects.set(<Forestry:bucketMead>, "metallum 8, aqua 2, fames 8, venenum 4, vacuos 1");
+
+mods.thaumcraft.Aspects.set(<Forestry:fluid.biomass>, "aqua 2, herba 2");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.glass>, "ignis 1, vitreus 3");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.bioethanol>, "aqua 2, potentia 4");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.honey>, "aqua 1, fames 3");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.ice>, "gelum 4");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.juice>, "aqua 2, fames 2, messis 2");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.seedoil>, "aqua 1, herba 3");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.short.mead>, "aqua 2, fames 4, venenum 4");
+mods.thaumcraft.Aspects.set(<Forestry:fluid.mead>, "aqua 2, fames 8, venenum 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:canEthanol>, "aqua 2, potentia 4");
+mods.thaumcraft.Aspects.set(<Forestry:canBiomass>, "aqua 2, herba 2");
+mods.thaumcraft.Aspects.set(<Forestry:canHoney>, "aqua 1, fames 3");
+mods.thaumcraft.Aspects.set(<Forestry:canIce>, "gelum 4");
+mods.thaumcraft.Aspects.set(<Forestry:canJuice>, "aqua 2, fames 2, messis 2");
+mods.thaumcraft.Aspects.set(<Forestry:canSeedOil>, "aqua 1, herba 3");
+mods.thaumcraft.Aspects.set(<Forestry:canShortMead>, "aqua 2, fames 4, venenum 4");
+mods.thaumcraft.Aspects.set(<Forestry:canMead>, "aqua 2, fames 8, venenum 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleEthanol>, "aqua 2, potentia 4");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleBiomass>, "aqua 2, herba 2");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleHoney>, "aqua 1, fames 3");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleIce>, "gelum 4");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleJuice>, "aqua 2, fames 2, messis 2");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleSeedOil>, "aqua 1, herba 3");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleShortMead>, "aqua 2, fames 4, venenum 4");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleMead>, "aqua 2, fames 8, venenum 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:refractoryEthanol>, "aqua 2, potentia 4");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryBiomass>, "aqua 2, herba 2");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryHoney>, "aqua 1, fames 3");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryIce>, "gelum 4");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryJuice>, "aqua 2, fames 2, messis 2");
+mods.thaumcraft.Aspects.set(<Forestry:refractorySeedOil>, "aqua 1, herba 3");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryShortMead>, "aqua 2, fames 4, venenum 4");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryMead>, "aqua 2, fames 8, venenum 4");
+
+mods.thaumcraft.Aspects.set(<Forestry:canWater>, "aqua 4");
+mods.thaumcraft.Aspects.set(<Forestry:waxCapsuleWater>, "aqua 4");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryWater>, "aqua 4");
+mods.thaumcraft.Aspects.set(<Forestry:canLava>, "ignis 4, terra 1");
+mods.thaumcraft.Aspects.set(<Forestry:refractoryLava>, "ignis 4, terra 1");
+
+# Trees
+mods.thaumcraft.Aspects.set(<Forestry:pollenFertile>, "herba 1");
+mods.thaumcraft.Aspects.set(<Forestry:fruits:*>, "messis 1, fames 1");
+mods.thaumcraft.Aspects.set(<Forestry:treealyzer>, "machina 4, sensus 4, arbor 4");
+
+# Butterflies
+mods.thaumcraft.Aspects.set(<Forestry:flutterlyzer>, "machina 4, sensus 4, bestia 2, volatus 2");
+mods.thaumcraft.Aspects.set(<Forestry:butterflyGE>, "bestia 1, volatus 1");
+mods.thaumcraft.Aspects.set(<Forestry:caterpillarGE>, "bestia 1");
+mods.thaumcraft.Aspects.set(<Forestry:serumGE>, "bestia 1");
+
+
+
+
+### Extra Trees ###
+# Author: daforsyth
+
+# Sawdust
+mods.thaumcraft.Aspects.set(<ExtraTrees:misc:1>, "arbor 1, perditio 1");
+
+# Bark
+mods.thaumcraft.Aspects.set(<ExtraTrees:misc:2>, "arbor 1");
+
+# Glass Fittings
+mods.thaumcraft.Aspects.set(<ExtraTrees:misc:5>, "metallum 1");
+
+# Wood Polish
+mods.thaumcraft.Aspects.set(<ExtraTrees:misc:4>, "sensus 1");
+
+# Gates / Fences
+mods.thaumcraft.Aspects.set(<ExtraTrees:gate:*>, "arbor 4, machina 1, iter 1");
+mods.thaumcraft.Aspects.set(<ExtraTrees:multifence:*>, "arbor 1");
+mods.thaumcraft.Aspects.set(<ExtraTrees:fence:*>, "arbor 1");
+
+# Custom Wood
+mods.thaumcraft.Aspects.set(<ExtraTrees:carpentry:*>, "arbor 1");
+
+# Custom Glass
+mods.thaumcraft.Aspects.set(<ExtraTrees:stainedglass:*>, "vitreus 1");
+
+# Food Stuff
+mods.thaumcraft.Aspects.set(<ExtraTrees:food:*>, "messis 1, fames 1");
+mods.thaumcraft.Aspects.add(<ExtraTrees:food:55>, "ignis 1");
+
+# Data Bases
+mods.thaumcraft.Aspects.set(<ExtraTrees:databaseMoth>, "machina 4, cognitio 4, bestia 2, volatus 2");
+mods.thaumcraft.Aspects.set(<ExtraTrees:database>, "machina 4, cognitio 4, arbor 4");
+
+
+
+### Extra Bees ###
+
+# Drops
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:1>, "venenum 2, perditio 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:2>, "venenum 4");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:3>, "fames 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:4>, "gelum 4");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:5>, "sano 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:6>, "herba 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:7>, "venenum 1");
+
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:8>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:9>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:10>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:11>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:12>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:13>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:14>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:15>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:16>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:17>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:18>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:19>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:20>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:21>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:22>, "permutatio 2, victus 2, sensus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:honeyDrop:23>, "permutatio 2, victus 2, sensus 1");
+
+# Fragments
+mods.thaumcraft.Aspects.set(<ExtraBees:misc:*>, "vitreus 1");
+mods.thaumcraft.Aspects.set(<ExtraBees:misc:*>, "vitreus 1");
+
+# Propolis
+mods.thaumcraft.Aspects.set(<ExtraBees:propolis:*>, "limus 1");
+
+# Ectoplasm
+mods.thaumcraft.Aspects.set(<ExtraBees:ectoplasm>, "spiritus 1, limus 1");
+
+# Alveary Unlighting
+mods.thaumcraft.Aspects.set(<ExtraBees:alveary:7>, "tenebrae 7, sensus 3, arbor 3, ordo 3, fabrico 3");
+
+# Database
+mods.thaumcraft.Aspects.set(<ExtraBees:dictionary>, "machina 4, cognitio 4, bestia 2, volatus 2");
+
+
+
+### Magic Bees ###
+# Author: daforsyth
+
+# Drops
+mods.thaumcraft.Aspects.set(<MagicBees:drop>, "praecantatio 2");
+mods.thaumcraft.Aspects.set(<MagicBees:drop:1>, "cognitio 2");
+mods.thaumcraft.Aspects.set(<MagicBees:drop:2>, "machina 2, potentia 1");
+mods.thaumcraft.Aspects.set(<MagicBees:drop:3>, "ignis 1, potentia 1");
+mods.thaumcraft.Aspects.set(<MagicBees:drop:4>, "lux 2");
+mods.thaumcraft.Aspects.set(<MagicBees:drop:5>, "alienis 2");
+
+# Combs
+mods.thaumcraft.Aspects.set(<MagicBees:comb:*>, "vinculum 2");
+
+
+# jelly babies
+mods.thaumcraft.Aspects.set(<MagicBees:jellyBabies>, "fames 4, gula 1");
+
+# emerald nugget
+mods.thaumcraft.Aspects.set(<MagicBees:beeNugget:6>, "vitreus 1");
+
+# Magic Backpack
+mods.thaumcraft.Aspects.set(<MagicBees:backpack.thaumaturgeT2>, "pannus 12, vacuos 6, praecantatio 4");
+mods.thaumcraft.Aspects.set(<MagicBees:backpack.thaumaturgeT1>, "pannus 6, vacuos 4, praecantatio 4");
+
+### Genetics ###
+
+# DNA
+mods.thaumcraft.Aspects.set(<Genetics:serumArray>, "vitreus 4, victus 4");
+mods.thaumcraft.Aspects.set(<Genetics:serum>, "vitreus 1, victus 1");
+mods.thaumcraft.Aspects.set(<Genetics:sequence:*>, "vitreus 1, victus 1");
+
+# Glass Container
+mods.thaumcraft.Aspects.set(<Genetics:misc:8>, "vitreus 1");
+
+# Growth Medium
+mods.thaumcraft.Aspects.set(<Genetics:misc:4>, "fames 1");
+
+# Enzyme
+mods.thaumcraft.Aspects.set(<Genetics:misc:3>, "limus 1, permutatio 1");
+
+# Machines
+mods.thaumcraft.Aspects.set(<Genetics:registry>, "machina 12, cognitio 12, bestia 6, arbor 6, volatus 6");
+mods.thaumcraft.Aspects.set(<Genetics:analyst>, "machina 12, sensus 12, bestia 6, arbor 6, volatus 6");
+mods.thaumcraft.Aspects.set(<Genetics:database>, "machina 4, sensus 4, victus 2");
+
+
+
+
+### Botany ###
+mods.thaumcraft.Aspects.set(<Botany:plant>, "herba 1");
+mods.thaumcraft.Aspects.set(<Botany:plant:1>, "herba 2");
+mods.thaumcraft.Aspects.set(<Botany:plant:2>, "herba 3");
+mods.thaumcraft.Aspects.set(<Botany:plant:4>, "herba 1, perditio 1");
+mods.thaumcraft.Aspects.set(<Botany:plant:3>, "herba 1, mortuus 1");
+
+# Flowers
+mods.thaumcraft.Aspects.set(<Botany:itemFlower>, "herba 1, victus 1, sensus 1");
+mods.thaumcraft.Aspects.set(<Botany:seed>, "herba 1");
+mods.thaumcraft.Aspects.set(<Botany:pollen>, "herba 1");
+
+# Soil
+mods.thaumcraft.Aspects.set(<Botany:soil:*>, "terra 2");
+mods.thaumcraft.Aspects.set(<Botany:soilNoWeed:*>, "terra 2");
+mods.thaumcraft.Aspects.set(<Botany:loamNoWeed:*>, "terra 2");
+mods.thaumcraft.Aspects.set(<Botany:flowerbedNoWeed:*>, "terra 2");
+
+
+
+# Ceramic
+mods.thaumcraft.Aspects.set(<Botany:ceramic:*>, "terra 2, ignis 2, sensus 1");
+mods.thaumcraft.Aspects.set(<Botany:stained:*>, "vitreus 1");
+mods.thaumcraft.Aspects.set(<Botany:ceramicPattern:*>, "terra 2, ignis 2, sensus 1");
+mods.thaumcraft.Aspects.set(<Botany:ceramicBrick:*>, "terra 2, ignis 2, sensus 1");
+
+# Matierals
+mods.thaumcraft.Aspects.set(<Botany:misc:6>, "terra 2, aqua 2");
+mods.thaumcraft.Aspects.set(<Botany:clay:*>, "terra 2, aqua 2, sensus 1");
+mods.thaumcraft.Aspects.set(<Botany:pigment:*>, "sensus 1");
+mods.thaumcraft.Aspects.set(<Botany:misc:7>, "venenum 1");
+
+# Database
+mods.thaumcraft.Aspects.set(<Botany:database>, "machina 4, sensus 4, herba 4");
+
+# Insulated Tubes
+mods.thaumcraft.Aspects.set(<Botany:insulatedTube:*>, "machina 1, vitreus 1, terra 1");
+
+
+
+
+### Binnies Core ###
+
+#Liquids
+
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:64>, "metallum 8, venenum 2, perditio 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:65>, "metallum 8, venenum 4, vacuos 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:66>, "metallum 8, aqua 1, fames 1, sano 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:67>, "metallum 8, aqua 1, fames 1, lux 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:68>, "metallum 8, gelum 6, aqua 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:131>, "metallum 8, aqua 2, arbor 1, ordo 1, vacuos 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerBucket:129>, "metallum 8, arbor 2, limus 2, vinculum 2, vacuos 1");
+
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:64>, "venenum 2, perditio 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:65>, "venenum 4");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:66>, "aqua 1, fames 1, sano 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:67>, "aqua 1, fames 1, lux 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:68>, "gelum 6, aqua 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:131>, "aqua 2, arbor 1, ordo 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCapsule:129>, "arbor 2, limus 2, vinculum 2");
+
+mods.thaumcraft.Aspects.set(<BinnieCore:containerRefractory:64>, "venenum 2, perditio 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerRefractory:65>, "venenum 4");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerRefractory:66>, "aqua 1, fames 1, sano 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerRefractory:67>, "aqua 1, fames 1, lux 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerRefractory:68>, "gelum 6, aqua 2");
+
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:64>, "venenum 2, perditio 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:65>, "venenum 4");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:66>, "aqua 1, fames 1, sano 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:67>, "aqua 1, fames 1, lux 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:68>, "gelum 6, aqua 2");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:131>, "aqua 2, arbor 1, ordo 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCan:129>, "arbor 2, limus 2, vinculum 2");
+
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCylinder:768>, "vitreus 1, fames 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCylinder:769>, "vitreus 1, victus 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCylinder:770>, "vitreus 1, victus 1, ordo 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCylinder:772>, "vitreus 1, victus 1, ordo 1");
+mods.thaumcraft.Aspects.set(<BinnieCore:containerCylinder:771>, "vitreus 1, victus 1, cognitio 1");
+
+# Field Kit
+mods.thaumcraft.Aspects.set(<BinnieCore:fieldKit>, "metallum 2, sensus 2");
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+print("Initialized 'Thaumcraft-Aspects-Binnies.zs'");

--- a/scripts/TC4- Aspects -LostScripts.zs
+++ b/scripts/TC4- Aspects -LostScripts.zs
@@ -1,0 +1,1177 @@
+### Blood Magic ###
+// Created by daforsyth
+
+# Armor
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundHelmet>, "victus 4, tutamen 3, infernus 5, spiritus 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundPlate>, "victus 4, tutamen 8, infernus 5, spiritus 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundLeggings>, "victus 4, tutamen 6, infernus 5, spiritus 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundBoots>, "victus 4, tutamen 3, infernus 5, spiritus 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sanguineHelmet>, "metallum 10, sensus 4, praecantatio 6, tutamen 2, victus 1 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sanguineRobe>, "metallum 24, praecantatio 12,  tutamen 6, victus 3 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sanguinePants>, "metallum 21, praecantatio 10,  tutamen 5, victus 2 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sanguineBoots>, "metallum 12, praecantatio 6,  tutamen 2, victus 1 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemBloodPack>, "metallum 6, tutamen 5, victus 3, telum 2, instrumentum 1, luxuria 1 ");
+
+# OMEGA
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundHelmetFire>, "victus 10, tutamen 10, infernus 20, ignis 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundPlateFire>, "victus 10, tutamen 30, infernus 20, ignis 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundLeggingsFire>, "victus 10, tutamen 20, infernus 20, ignis 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundBootsFire>, "victus 10, tutamen 10, infernus 20, ignis 25, superbia 10");
+
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundHelmetEarth>, "victus 10, tutamen 10, infernus 20, terra 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundPlateEarth>, "victus 10, tutamen 30, infernus 20, terra 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundLeggingsEarth>, "victus 10, tutamen 20, infernus 20, terra 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundBootsEarth>, "victus 10, tutamen 10, infernus 20, terra 25, superbia 10");
+
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundHelmetWind>, "victus 10, tutamen 10, infernus 20, aer 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundPlateWind>, "victus 10, tutamen 30, infernus 20, aer 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundLeggingsWind>, "victus 10, tutamen 20, infernus 20, aer 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundBootsWind>, "victus 10, tutamen 10, infernus 20, aer 25, superbia 10");
+
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundHelmetWater>, "victus 10, tutamen 10, infernus 20, aqua 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundPlateWater>, "victus 10, tutamen 30, infernus 20, aqua 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundLeggingsWater>, "victus 10, tutamen 20, infernus 20, aqua 25, superbia 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundBootsWater>, "victus 10, tutamen 10, infernus 20, aqua 25, superbia 10");
+
+# Slates
+mods.thaumcraft.Aspects.set(<AWWayofTime:blankSlate>, "terra 1, victus 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:reinforcedSlate>, "terra 2, victus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:imbuedSlate>, "terra 3, victus 3, praecantatio 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:demonicSlate>, "terra 4, victus 4, praecantatio 2, infernus 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:27>, "terra 5, victus 5, praecantatio 3, infernus 2, spiritus 1");
+
+# Potions stuff
+mods.thaumcraft.Aspects.set(<AWWayofTime:weakBloodShard>, "victus 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:mundaneLengtheningCatalyst>, "praecantatio 1, potentia 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:averageLengtheningCatalyst>, "praecantatio 3, potentia 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:greaterLengtheningCatalyst>, "praecantatio 5, potentia 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:mundanePowerCatalyst>, "praecantatio 1, lux 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:averagePowerCatalyst>, "praecantatio 3, lux 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:greaterPowerCatalyst>, "praecantatio 5, lux 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:weakFillingAgent>, "praecantatio 1, lux 1, potentia 1, aqua 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:standardFillingAgent>, "praecantatio 3, lux 3, potentia 3, aqua 3, terra 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:enhancedFillingAgent>, "praecantatio 5, lux 5, potentia 5, aqua 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:weakBindingAgent>, "lux 2, potentia 2, aqua 2, terra 2, perditio 2, fames 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:standardBindingAgent>, "lux 6, potentia 4, aqua 4, terra 4, perditio 4, gelum 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:alchemyFlask>, "vacuos 8");
+
+# Runes
+mods.thaumcraft.Aspects.set(<AWWayofTime:runeOfSelfSacrifice>, "terra 4, victus 2, luxuria 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:AlchemicalWizardrybloodRune:1>, "terra 4, victus 2, vacuos 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:AlchemicalWizardrybloodRune:3>, "terra 4, victus 2, iter 2, vacuos 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:AlchemicalWizardrybloodRune:4>, "terra 4, victus 4, vacuos 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:AlchemicalWizardrybloodRune:5>, "terra 4, victus 4, motus 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:speedRune>, "terra 4, victus 2, motus 2, fames 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:AlchemicalWizardrybloodRune>, "terra 4, victus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:AlchemicalWizardrybloodRune:2>, "terra 4, victus 4, motus 2, aqua 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:runeOfSacrifice>, "terra 4, victus 2, telum 2, fames 2");
+
+# Sigils
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfEnderSeverance>, "praecantatio 4, alienis 4, vinculum 4, iter 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:lavaSigil>, "praecantatio 4, ignis 6, vacuos 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:airSigil>, "praecantatio 4, aer 4, volatus 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfTheFastMiner>, "praecantatio 4, perfodio 4, motus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:growthSigil>, "praecantatio 4, herba 6, victus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:waterSigil>, "praecantatio 4, aqua 6, vacuos 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemBloodLightSigil>, "praecantatio 4, lux 8, sensus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:voidSigil>, "praecantatio 4, vacuos 8, perditio 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:divinationSigil>, "praecantatio 4, spiritus 2, sensus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:seerSigil>, "praecantatio 4, machina 4, sensus 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfSupression>, "praecantatio 4, aqua 8, vacuos 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemCompressionSigil>, "praecantatio 4, fabrico 8, vacuos 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemHarvestSigil>, "praecantatio 4, meto 8, messis 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfTheBridge>, "praecantatio 4, iter 4, tenebrae 4, spiritus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfMagnetism>, "praecantatio 4, iter 2, permutatio 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfWind>, "praecantatio 4, aer 8, tutamen 4, volatus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfHolding>, "praecantatio 4, vacuos 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfElementalAffinity>, "terra 8, praecantatio 4, ignis 4, aer 4, aqua 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sigilOfHaste>, "praecantatio 4, motus 8, fames 4");
+
+# Inscription tools
+mods.thaumcraft.Aspects.set(<AWWayofTime:waterScribeTool>, "instrumentum 4, victus 1, aqua 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:fireScribeTool>, "instrumentum 4, victus 1, ignis 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:airScribeTool>, "instrumentum 4, victus 1, aer 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:earthScribeTool>, "instrumentum 4, victus 1, terra 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:duskScribeTool>, "instrumentum 4, victus 1, ordo 4, perditio 4, tenebrae 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:dawnScribeTool>, "instrumentum 4, victus 1, ordo 4, perditio 4, lux 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemRitualDiviner>, "instrumentum 4, machina 1, aqua 1, terra 1, ignis 1, aer 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemRitualDiviner:1>, "instrumentum 4, machina 1, ordo 1, perditio 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemRitualDiviner:2>, "instrumentum 4, machina 1, ordo 1, perditio 1, lux 1");
+
+# Devices
+mods.thaumcraft.Aspects.add(<AWWayofTime:blockCrystalBelljar>, "vacuos 2");
+mods.thaumcraft.Aspects.add(<AWWayofTime:emptySocket>, "vinculum 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodSocket>, "vinculum 3, lucrum 3, vitreus 6, victus 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:imperfectRitualStone>, "terra 4, praecantatio 4, auram 1, victus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:armourForge>, "fabrico 15, victus 5, tutamen 20, spiritus 15");
+mods.thaumcraft.Aspects.set(<AWWayofTime:blockHomHeart>, "terra 6, fabrico 4, praecantatio 12");
+mods.thaumcraft.Aspects.add(<AWWayofTime:blockCrucible>, "ignis 2, aer 1");
+mods.thaumcraft.Aspects.add(<AWWayofTime:blockReagentConduit>, "metallum 12, machina 6, praecantatio 5, iter 4 ");
+mods.thaumcraft.Aspects.add(<AWWayofTime:blockWritingTable>, "ignis 3, perditio 3, terra 3, aqua 3, praecantatio 1, victus 3");
+
+# Tools
+mods.thaumcraft.Aspects.set(<AWWayofTime:ritualDismantler>, "instrumentum 4, perditio 4, machina 4, potentia 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:blankSpell>, "praecantatio 4, alienis 2, vitreus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemComplexSpellCrystal>, "praecantatio 10, alienis 4, vitreus 8, sensus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:lavaCrystal>, "ignis 10, vitreus 4, victus 4, terra 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:activationCrystal>, "instrumentum 4, praecantatio 2, spiritus 2, machina 2, victus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:activationCrystal:1>, "instrumentum 4, praecantatio 8, spiritus 8, machina 4, victus 6, superbia 8");
+mods.thaumcraft.Aspects.set(<AWWayofTime:armourInhibitor>, "spiritus 4, vinculum 4, metallum 10, victus 4 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemAttunedCrystal>, "instrumentum 2, potentia 4, alienis 2, iter 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemTankSegmenter>, "instrumentum 2, potentia 4, alienis 2, ordo 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:itemDestinationClearer>, "instrumentum 2, potentia 4, alienis 2, perditio 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:daggerOfSacrifice>, "telum 3, fames 3, metallum 6");
+mods.thaumcraft.Aspects.add(<AWWayofTime:sacrificialKnife>, "telum 3, luxuria 1");
+mods.thaumcraft.Aspects.add(<AWWayofTime:demonPlacer>, "alienis 4, infernus 4");
+
+# BOUND TOOLS
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundShovel>, "instrumentum 6, victus 4, spiritus 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundAxe>, "instrumentum 6, victus 4, spiritus 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energySword>, "telum 6, victus 4, spiritus 3 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:boundPickaxe>, "perfodio 6, victus 4, spiritus 3  ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBazooka>, "ira 32, ignis 16, perditio 32, telum 32");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBazookaSecondTier>, "ira 32, ignis 16, perditio 32, telum 32");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBazookaThirdTier>, "ira 32, ignis 16, perditio 32, telum 32");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBlasterSecondTier>, "ira 6, alienis 5, venenum 1, telum 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBlasterThirdTier>, "ira 6, alienis 5, venenum 1, telum 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBazookaSecondTier>, "ira 32, ignis 16, perditio 32, telum 32");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBazookaThirdTier>, "ira 32, ignis 16, perditio 32, telum 32");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBlasterSecondTier>, "ira 6, alienis 5, venenum 1, telum 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:energyBlasterThirdTier>, "ira 6, alienis 5, venenum 1, telum 6");
+
+# Incense
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicIncenseItem>, "aer 4, arbor 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicIncenseItem:1>, "aer 4, sensus 2,praecantatio 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicIncenseItem:2>, "aer 4, sensus 2,praecantatio 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicIncenseItem:3>, "aer 4, sensus 2,praecantatio 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicIncenseItem:4>, "aer 4, sensus 2, praecantatio 1");
+
+
+# Plates and Crystals
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:15>, "terra 4, tutamen 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:16>, "terra 8, tutamen 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:17>, "terra 8, tutamen 4, aqua 4, ignis 4, praecantatio 4 ");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:28>, "vitreus 5, victus 20");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:29>, "vitreus 5, spiritus 20");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:30>, "terra 16, tutamen 8, aqua 4, ignis 4, praecantatio 4, spiritus 16 ");
+mods.thaumcraft.Aspects.add(<AWWayofTime:itemMailCatalogue>, "tempestas 1");
+
+# Demons / Rituals
+mods.thaumcraft.Aspects.set(<AWWayofTime:demonPortalMain>, "iter 5, infernus 25, alienis, humanus 20, praecantatio 10");
+mods.thaumcraft.Aspects.set(<AWWayofTime:blockDemonChest>, "vacuos 4, infernus 5, lucrum 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:spectralBlock>, "iter 1, spiritus 3, tenebrae 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:ritualStone>, "terra 4, victus 1, machina 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:masterStone>, "terra 6, victus 4, machina 10, praecantatio 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:lifeEssence>, "aqua 4, victus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:largeBloodStoneBrick>, "terra 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodStoneBrick>, "terra 1");
+
+# Teleposition foci
+mods.thaumcraft.Aspects.set(<AWWayofTime:telepositionFocus>, "alienis 1, motus 1, iter 1, victus 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:enhancedTelepositionFocus>, "alienis 2, motus 2, iter 2, victus 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:reinforcedTelepositionFocus>, "alienis 4, motus 4, iter 4, victus 4");
+mods.thaumcraft.Aspects.set(<AWWayofTime:demonicTelepositionFocus>, "alienis 8, motus 8, iter 8, victus 8");
+
+# Reagents
+mods.thaumcraft.Aspects.set(<AWWayofTime:aether>, "aer 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:tennebrae>, "tenebrae 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:aquasalus>, "aqua 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:terrae>, "terra 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:crystallos>, "gelum 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:sanctus>, "lux 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:incendium>, "ignis 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:magicales>, "praecantatio 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:crepitous>, "perditio 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:5>, "mortuus 2, perditio 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:simpleCatalyst>, "potentia 1, lux 1, perditio 1, fames 1, ignis 1");
+
+# MISC
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:32>, "alienis 1");
+mods.thaumcraft.Aspects.add(<AWWayofTime:outputRoutingFocus>, "iter 1");
+mods.thaumcraft.Aspects.add(<AWWayofTime:inputRoutingFocus:*>, "iter 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodLight>, "lux 1, victus 1");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bucketLife>, "aqua 4, victus 4, vacuos 1, metallum 8 ");
+
+# Spell Parts
+mods.thaumcraft.Aspects.add(<AWWayofTime:bloodMagicBaseItems:4>, "terra 6");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:3>, "potentia 2, ordo 2, perditio 2");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:4>, "potentia 4, ordo 4, perditio 4");
+
+# Cores
+
+mods.thaumcraft.Aspects.add(<AWWayofTime:bloodMagicBaseItems:1>, "vitreus 7");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:5>, "vitreus 10, volatus 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:6>, "vitreus 10, humanus 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:7>, "vitreus 10, ira 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:10>, "vitreus 10, ignis 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:11>, "vitreus 10, gelum 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:12>, "vitreus 10, aer 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:13>, "vitreus 10, terra 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:18>, "vitreus 10, vacuos 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:19>, "vitreus 10, telum 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:20>, "vitreus 10, tutamen 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:21>, "vitreus 10, herba 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:22>, "vitreus 10, lux 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:23>, "vitreus 10, permutatio 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:24>, "vitreus 10, potentia 5");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseItems:26>, "vitreus 10, instrumentum 5");
+
+# Spell Powders
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems>, "telum 3, ira 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:1>, "tutamen 3, metallum 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:2>, "terra 3, herba 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:6>, "potentia 3, ignis 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:7>, "terra 3, permutatio 3");
+mods.thaumcraft.Aspects.set(<AWWayofTime:bloodMagicBaseAlchemyItems:8>, "potentia 3, lux 3");
+
+# Demons
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.EarthElemental", "terra 6, infernus 6, auram 12");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.FireElemental", "ignis 6, infernus 6, auram 12");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.ShadeElemental", "tenebrae 6, infernus 6, auram 12");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.HolyElemental", "lux 6, infernus 6, auram 12");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.WaterElemental", "aqua 6, infernus 6, auram 12");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.AirElemental", "aer 6, infernus 6, auram 12");
+
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.Shade", "tenebrae 3, infernus 2, spiritus 3");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.BoulderFist", "terra 3, infernus 2, bestia 3");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.IceDemon", "gelum 3, infernus 2");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.SmallEarthGolem", "terra 3, infernus 2, humanus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.LowerGuardian", "humanus 1, infernus 2, tenebrae 3, vacuos 3");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.FallenAngel", "humanus 3, infernus 2, volatus 3, lux 2");
+
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.WingedFireDemon", "ignis 10, infernus 12, volatus 6");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.BileDemon", "ignis 10, infernus 12, fames 6");
+
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntGuardianWind", "aer 5, infernus 16, tutamen 4");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntGuardianFire", "ignis 5, infernus 16, tutamen 4");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntGuardianIce", "gelum 5, infernus 16, tutamen 4");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntGuardianEarth", "terra 5, infernus 16, tutamen 4");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntWind", "aer 3, infernus 16");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntFire", "ignis 3, infernus 16");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntIce", "gelum 3, infernus 16");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGruntEarth", "terra 3, infernus 16");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.MinorDemonGrunt", "infernus 16");
+
+#Entities
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.particleBeam", "praecantatio 3");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.bloodLightProjectile", "lux 1, motus 2");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.spellProjectile", "praecantatio 3, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.energyBazookaMain", "ignis 4, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.energyBazookaSecondary", "ignis 2, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.meteor", "ignis 4, terra 4");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.teleportProjectile", "alienis 3, motus 3");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.mudProjectile", "terra 1, aqua 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.waterProjectile", "aqua 2, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.lightningBoltProjectile", "tempestas 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.windGustProjectile", "aer 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.holyProjectile", "lux 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.explosionProjectile", "ira 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.iceProjectile", "gelum 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.fireProjectile", "ignis 1, motus 1");
+mods.thaumcraft.Aspects.setEntity("AWWayofTime.energyBlastProjectile", "potentia 1, motus 1");
+
+
+
+
+### Electrobobs Wizardry ###
+// Created by daforsyth
+
+# Entities
+mods.thaumcraft.Aspects.setEntity("wizardry.Wizard", "praecantatio 1, humanus 3");
+mods.thaumcraft.Aspects.setEntity("wizardry.Evil Wizard", "vitium 1, humanus 3");
+
+mods.thaumcraft.Aspects.setEntity("wizardry.Skeleton Minion", "exanimis 1, praecantatio 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Zombie Minion", "exanimis 1, praecantatio 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Blaze Minion", "ignis 1, alienis 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Silverfish Minion", "bestia 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Spider Minion", "bestia 1");
+
+mods.thaumcraft.Aspects.setEntity("wizardry.Spirit Horse", "bestia 4, spiritus 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Spirit Wolf", "bestia 3, spiritus 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Ice Wraith", "gelum 1, alienis 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Lightning Wraith", "tempestas 1, alienis 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Storm Elemental", "tempestas 1, potentia 1, alienis 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Shadow Wraith", "tenebrae 1, alienis 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Phoenix", "bestia 8, ignis 7, permutatio 3, volatus 4");
+mods.thaumcraft.Aspects.setEntity("wizardry.Ice Giant", "praecantatio 3, gelum 5, humanus 3");
+
+mods.thaumcraft.Aspects.setEntity("wizardry.Bubble", "tenebrae 1, vacuos 1");
+mods.thaumcraft.Aspects.setEntity("wizardry.Decoy", "sensus 4, praecantatio 4");
+mods.thaumcraft.Aspects.setEntity("wizardry.Lightning Hammer", "telum 20, tempestas 10, potentia 10, praecantatio 10");
+mods.thaumcraft.Aspects.setEntity("wizardry.Tornado", "aer 20, motus 10");
+
+# Items
+mods.thaumcraft.Aspects.add(<wizardry:transportation_stone>, "iter 1");
+mods.thaumcraft.Aspects.set(<wizardry:magic_crystal>, "vitreus 1, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:mana_flask>, "vitreus 1, praecantatio 4");
+mods.thaumcraft.Aspects.add(<wizardry:magic_silk>, "praecantatio 0");
+mods.thaumcraft.Aspects.set(<wizardry:ice_statue>, "gelum 4, vinculum 1");
+mods.thaumcraft.Aspects.set(<wizardry:snare>, "herba 3, vinculum 1");
+mods.thaumcraft.Aspects.set(<wizardry:magic_light>, "lux 1, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:petrified_stone>, "terra 3, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:spectral_block>, "spiritus 3, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:meteor>, "ignis 4, terra 4");
+mods.thaumcraft.Aspects.set(<wizardry:vanishing_cobweb>, "vinculum 2, pannus 1");
+
+# Books
+mods.thaumcraft.Aspects.set(<wizardry:spell_book:*>, "cognitio 4, praecantatio 4");
+mods.thaumcraft.Aspects.set(<wizardry:scroll:*>, "cognitio 1, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:wizard_handbook>, "cognitio 1, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:blank_scroll>, "cognitio 1");
+mods.thaumcraft.Aspects.set(<wizardry:identification_scroll>, "cognitio 1, praecantatio 1, sensus 1");
+mods.thaumcraft.Aspects.set(<wizardry:armour_upgrade>, "praecantatio 4, cognitio 4, tutamen 4");
+
+# Master Books
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:91>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:92>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:93>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:94>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:95>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:96>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:97>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:98>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:99>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:100>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:101>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:102>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:103>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:104>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:105>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:106>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:107>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:108>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:109>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:110>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:136>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:137>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:138>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:139>, "superbia 1");
+mods.thaumcraft.Aspects.add(<wizardry:spell_book:140>, "superbia 1");
+
+# Bombs
+mods.thaumcraft.Aspects.set(<wizardry:smoke_bomb>, "tenebrae 3");
+mods.thaumcraft.Aspects.set(<wizardry:firebomb>, "ignis 3");
+mods.thaumcraft.Aspects.set(<wizardry:poison_bomb>, "venenum 3");
+
+# Ores
+mods.thaumcraft.Aspects.set(<wizardry:crystal_ore>, "terra 1, vitreus 1, praecantatio 1");
+mods.thaumcraft.Aspects.set(<wizardry:crystal_flower>, "herba 1, victus 1, sensus 1, vitreus 1");
+mods.thaumcraft.Aspects.set(<wizardry:crystal_block>, "vitreus 9, praecantatio 9");
+
+# Upgrades
+mods.thaumcraft.Aspects.set(<wizardry:storage_upgrade>, "praecantatio 4, vacuos 3");
+mods.thaumcraft.Aspects.set(<wizardry:siphon_upgrade>, "praecantatio 4, fames 3");
+mods.thaumcraft.Aspects.set(<wizardry:condenser_upgrade>, "praecantatio 4, ordo 3");
+mods.thaumcraft.Aspects.set(<wizardry:range_upgrade>, "praecantatio 4, iter 3");
+mods.thaumcraft.Aspects.set(<wizardry:duration_upgrade>, "praecantatio 4, tempus 3");
+mods.thaumcraft.Aspects.set(<wizardry:cooldown_upgrade>, "praecantatio 4, gelum 3");
+mods.thaumcraft.Aspects.set(<wizardry:blast_upgrade>, "praecantatio 4, ira 3");
+mods.thaumcraft.Aspects.set(<wizardry:attunement_upgrade>, "praecantatio 4, instrumentum 3");
+
+# Armor
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat>, "praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe>, "praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings>, "praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots>, "praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_fire>, "pannus 3, ignis 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_fire>, "pannus 6, ignis 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_fire>, "pannus 5, ignis 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_fire>, "pannus 3, ignis 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_ice>, "pannus 3, gelum 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_ice>, "pannus 6, gelum 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_ice>, "pannus 5, gelum 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_ice>, "pannus 3, gelum 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_lightning>, "pannus 3, tempestas 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_lightning>, "pannus 6, tempestas 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_lightning>, "pannus 5, tempestas 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_lightning>, "pannus 3, tempestas 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_necromancy>, "pannus 3, exanimis 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_necromancy>, "pannus 6, exanimis 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_necromancy>, "pannus 5, exanimis 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_necromancy>, "pannus 3, exanimis 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_earth>, "pannus 3, terra 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_earth>, "pannus 6, terra 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_earth>, "pannus 5, terra 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_earth>, "pannus 3, terra 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_sorcery>, "pannus 3, auram 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_sorcery>, "pannus 6, auram 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_sorcery>, "pannus 5, auram 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_sorcery>, "pannus 3, auram 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:wizard_hat_healing>, "pannus 3, sano 2, praecantatio 1");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_robe_healing>, "pannus 6, sano 5, praecantatio 3");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_leggings_healing>, "pannus 5, sano 4, praecantatio 2");
+mods.thaumcraft.Aspects.add(<wizardry:wizard_boots_healing>, "pannus 3, sano 2, praecantatio 1");
+
+mods.thaumcraft.Aspects.add(<wizardry:spectral_helmet>, "spiritus 2");
+mods.thaumcraft.Aspects.add(<wizardry:spectral_chestplate>, "spiritus 6");
+mods.thaumcraft.Aspects.add(<wizardry:spectral_leggings>, "spiritus 5");
+mods.thaumcraft.Aspects.add(<wizardry:spectral_boots>, "spiritus 2");
+
+# Tools
+mods.thaumcraft.Aspects.set(<wizardry:frost_axe:1>, "telum 4, gelum 3, praecantatio 2");
+mods.thaumcraft.Aspects.set(<wizardry:flaming_axe:1>, "telum 4, ignis 3, praecantatio 2");
+
+mods.thaumcraft.Aspects.add(<wizardry:spectral_sword:1>, "spiritus 2");
+mods.thaumcraft.Aspects.add(<wizardry:spectral_pickaxe:1>, "spiritus 2");
+mods.thaumcraft.Aspects.add(<wizardry:spectral_bow:1>, "spiritus 2");
+
+# Wands
+mods.thaumcraft.Aspects.set(<wizardry:magic_wand>, "instrumentum 1, praecantatio 1, ordo 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_wand>, "instrumentum 2, praecantatio 2, ordo 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_wand>, "instrumentum 4, praecantatio 4, ordo 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_wand>, "instrumentum 8, praecantatio 8, ordo 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_fire_wand>, "instrumentum 1, praecantatio 1, ordo 1, ignis 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_fire_wand>, "instrumentum 2, praecantatio 2, ordo 2, ignis 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_fire_wand>, "instrumentum 4, praecantatio 4, ordo 4, ignis 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_fire_wand>, "instrumentum 8, praecantatio 8, ordo 8, ignis 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_ice_wand>, "instrumentum 1, praecantatio 1, ordo 1, gelum 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_ice_wand>, "instrumentum 2, praecantatio 2, ordo 2, gelum 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_ice_wand>, "instrumentum 4, praecantatio 4, ordo 4, gelum 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_ice_wand>, "instrumentum 8, praecantatio 8, ordo 8, gelum 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_lightning_wand>, "instrumentum 1, praecantatio 1, ordo 1, tempestas 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_lightning_wand>, "instrumentum 2, praecantatio 2, ordo 2, tempestas 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_lightning_wand>, "instrumentum 4, praecantatio 4, ordo 4, tempestas 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_lightning_wand>, "instrumentum 8, praecantatio 8, ordo 8, tempestas 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_necromancy_wand>, "instrumentum 1, praecantatio 1, ordo 1, exanimis 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_necromancy_wand>, "instrumentum 2, praecantatio 2, ordo 2, exanimis 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_necromancy_wand>, "instrumentum 4, praecantatio 4, ordo 4, exanimis 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_necromancy_wand>, "instrumentum 8, praecantatio 8, ordo 8, exanimis 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_earth_wand>, "instrumentum 1, praecantatio 1, ordo 1, terra 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_earth_wand>, "instrumentum 2, praecantatio 2, ordo 2, terra 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_earth_wand>, "instrumentum 4, praecantatio 4, ordo 4, terra 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_earth_wand>, "instrumentum 8, praecantatio 8, ordo 8, terra 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_sorcery_wand>, "instrumentum 1, praecantatio 1, ordo 1, auram 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_sorcery_wand>, "instrumentum 2, praecantatio 2, ordo 2, auram 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_sorcery_wand>, "instrumentum 4, praecantatio 4, ordo 4, auram 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_sorcery_wand>, "instrumentum 8, praecantatio 8, ordo 8, auram 8");
+
+mods.thaumcraft.Aspects.set(<wizardry:basic_healing_wand>, "instrumentum 1, praecantatio 1, ordo 1, sano 1");
+mods.thaumcraft.Aspects.set(<wizardry:apprentice_healing_wand>, "instrumentum 2, praecantatio 2, ordo 2, sano 2");
+mods.thaumcraft.Aspects.set(<wizardry:advanced_healing_wand>, "instrumentum 4, praecantatio 4, ordo 4, sano 4");
+mods.thaumcraft.Aspects.set(<wizardry:master_healing_wand>, "instrumentum 8, praecantatio 8, ordo 8, sano 8");
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### Mekanism ###
+// Created by daforsyth
+
+# Machine Parts
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:8>, "metallum 8, vitreus 2, ordo 3");
+mods.thaumcraft.Aspects.set(<Mekanism:ControlCircuit>, "metallum 1, cognitio 1, potentia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:ControlCircuit:1>, "metallum 2, cognitio 3, potentia 2");
+mods.thaumcraft.Aspects.set(<Mekanism:ControlCircuit:2>, "metallum 4, cognitio 4, potentia 4, lucrum 2");
+mods.thaumcraft.Aspects.set(<Mekanism:ControlCircuit:3>, "metallum 6, cognitio 6, potentia 6, lucrum 12, superbia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:EnrichedAlloy>, "metallum 1, potentia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:ReinforcedAlloy>, "metallum 3, potentia 3, lucrum 2");
+mods.thaumcraft.Aspects.set(<Mekanism:AtomicAlloy>, "metallum 5, potentia 5, lucrum 3, ordo 4");
+mods.thaumcraft.Aspects.set(<Mekanism:CompressedDiamond>, "lucrum 4, vitreus 4, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:CompressedRedstone>, "potentia 2, machina 1, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:CompressedCarbon>, "potentia 2, ignis 2, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:CompressedObsidian>, "tenebrae 1, ignis 2, perditio 1, lucrum 1, ordo 1");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:TurbineBlade>, "metallum 7, motus 1, ordo 2");
+mods.thaumcraft.Aspects.set(<Mekanism:TeleportationCore>, "metallum 8, alienis 4, potentia 6, lucrum 8");
+mods.thaumcraft.Aspects.set(<Mekanism:ElectrolyticCore>, "metallum 2, potentia 1, permutatio 3");
+mods.thaumcraft.Aspects.set(<Mekanism:FactoryInstaller>, "metallum 2, cognitio 2, potentia 2, machina 2");
+mods.thaumcraft.Aspects.set(<Mekanism:FactoryInstaller:1>, "metallum 3, cognitio 5, potentia 3, machina 3");
+mods.thaumcraft.Aspects.set(<Mekanism:FactoryInstaller:2>, "metallum 7, cognitio 7, potentia 7, lucrum 3, machina 7");
+mods.thaumcraft.Aspects.set(<Mekanism:FactoryInstaller:3>, "metallum 11, cognitio 11, potentia 11, lucrum 23, superbia 2, machina 11");
+mods.thaumcraft.Aspects.set(<Mekanism:EnergyTablet>, "metallum 11, potentia 8, lucrum 3");
+mods.thaumcraft.Aspects.set(<Mekanism:GasUpgrade>, "metallum 2, potentia 1, cognitio 1, aer 3");
+mods.thaumcraft.Aspects.set(<Mekanism:MufflingUpgrade>, "metallum 2, potentia 1, cognitio 1, sensus 3");
+mods.thaumcraft.Aspects.set(<Mekanism:FilterUpgrade>, "metallum 2, potentia 1, cognitio 1, permutatio 3");
+mods.thaumcraft.Aspects.set(<Mekanism:EnergyUpgrade>, "metallum 2, cognitio 1, potentia 4");
+mods.thaumcraft.Aspects.set(<Mekanism:SpeedUpgrade>, "metallum 2, potentia 1, cognitio 1, motus 3");
+
+# Materials
+mods.thaumcraft.Aspects.set(<Mekanism:Ingot>, "metallum 3, terra 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Ingot:1>, "metallum 3, machina 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Ingot:3>, "metallum 3, terra 1, lux 1");
+mods.thaumcraft.Aspects.set(<Mekanism:OreBlock>, "metallum 2, machina 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:1>, "metallum 20, instrumentum 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:2>, "metallum 20, tenebrae 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:3>, "potentia 13, ignis 13");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:4>, "metallum 20, lux 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:5>, "metallum 20, ordo 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:12>, "metallum 20, permutatio 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:13>, "metallum 20, vitreus 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock>, "metallum 20, machina 6");
+mods.thaumcraft.Aspects.set(<Mekanism:Sawdust>, "arbor 1, perditio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Salt>, "aqua 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:SaltBlock>, "aqua 3, terra 3");
+mods.thaumcraft.Aspects.set(<Mekanism:OtherDust>, "lucrum 3, vitreus 2, perditio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:OtherDust:1>, "metallum 2, ordo 1, perditio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:OtherDust:3>, "ignis 3, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:OtherDust:4>, "potentia 3, ignis 2, venenum 1");
+mods.thaumcraft.Aspects.set(<Mekanism:OtherDust:5>, "tenebrae 1, ignis 2, perditio 1, lucrum 1");
+mods.thaumcraft.Aspects.set(<Mekanism:OtherDust:6>, "tenebrae 1, ignis 2, perditio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:EnrichedIron>, "metallum 1, ordo 1, perditio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Substrate>, "terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Polyethene>, "terra 1, humanus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Polyethene:1>, "terra 3, humanus 3");
+mods.thaumcraft.Aspects.set(<Mekanism:Polyethene:2>, "terra 3, humanus 3, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Polyethene:3>, "terra 5, humanus 5");
+mods.thaumcraft.Aspects.set(<Mekanism:BioFuel>, "herba 1, perditio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:BrineBucket>, "metallum 8, vacuos 1, aqua 4, terra 4");
+mods.thaumcraft.Aspects.set(<Mekanism:LithiumBucket>, "metallum 8, vacuos 1, aqua 4, venenum 2, ignis 2");
+mods.thaumcraft.Aspects.set(<Mekanism:HeavyWaterBucket>, "metallum 8, vacuos 1, aqua 4, vinculum 4");
+
+# Processed Ores
+mods.thaumcraft.Aspects.set(<Mekanism:Shard>, "metallum 3");
+mods.thaumcraft.Aspects.set(<Mekanism:Shard:1>, "metallum 2, lucrum 2");
+mods.thaumcraft.Aspects.set(<Mekanism:Shard:2>, "metallum 2, machina 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Shard:3>, "metallum 2, permutatio 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Shard:4>, "metallum 2, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Shard:5>, "metallum 2, lucrum 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Shard:6>, "metallum 2, ordo 1");
+
+mods.thaumcraft.Aspects.set(<Mekanism:Clump>, "metallum 3, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Clump:1>, "metallum 2, lucrum 2, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Clump:2>, "metallum 2, machina 1, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Clump:3>, "metallum 2, permutatio 1, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Clump:4>, "metallum 2, vitreus 1, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Clump:5>, "metallum 2, lucrum 1, ordo 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Clump:6>, "metallum 2, ordo 2");
+
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust>, "metallum 3, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust:1>, "metallum 2, lucrum 2, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust:2>, "metallum 2, machina 1, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust:3>, "metallum 2, permutatio 1, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust:4>, "metallum 2, vitreus 1, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust:5>, "metallum 2, lucrum 1, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<Mekanism:DirtyDust:6>, "metallum 2, ordo 1, perditio 1, terra 1");
+
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal>, "metallum 3, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal:1>, "metallum 2, lucrum 2, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal:2>, "metallum 2, machina 1, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal:3>, "metallum 2, permutatio 1, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal:4>, "metallum 2, vitreus 2");
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal:5>, "metallum 2, lucrum 1, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:Crystal:6>, "metallum 2, ordo 1, vitreus 1");
+
+# Tools
+mods.thaumcraft.Aspects.set(<Mekanism:Dictionary>, "cognitio 2, potentia 1, machina 2");
+mods.thaumcraft.Aspects.set(<Mekanism:NetworkReader>, "permutatio 1, potentia 1, instrumentum 2");
+mods.thaumcraft.Aspects.set(<Mekanism:WalkieTalkie>, "sensus 1, potentia 1, instrumentum 1");
+mods.thaumcraft.Aspects.set(<Mekanism:FreeRunners>, "metallum 13, motus 6, tutamen 1, machina 3");
+mods.thaumcraft.Aspects.set(<Mekanism:Jetpack>, "metallum 11, volatus 8, tutamen 1, machina 3, ignis 8");
+mods.thaumcraft.Aspects.set(<Mekanism:ArmoredJetpack>, "metallum 11, volatus 8, tutamen 9, machina 3, ignis 8");
+mods.thaumcraft.Aspects.set(<Mekanism:ScubaTank>, "metallum 3, aer 4, vacous 4, tutamen 1");
+mods.thaumcraft.Aspects.set(<Mekanism:GasMask>, "metallum 5, aer 4, permutatio 4, tutamen 1, vitreus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:AtomicDisassembler>, "metallum 11, instrumentum 20, perfodio 20, potentia 6");
+mods.thaumcraft.Aspects.set(<Mekanism:ElectricBow>, "metallum 6, telum 5, pannus 2, bestia 2, volatus 2");
+mods.thaumcraft.Aspects.set(<Mekanism:Configurator>, "metallum 3, instrumentum 1, machina 1");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Hohlraum>, "metallum 4, instrumentum 1, vacuos 3");
+mods.thaumcraft.Aspects.set(<Mekanism:GaugeDropper>, "vitreus 3, instrumentum 1, vacuos 1");
+mods.thaumcraft.Aspects.set(<Mekanism:SeismicReader>, "metallum 8, sensus 4, potentia 2");
+mods.thaumcraft.Aspects.set(<Mekanism:CraftingFormula>, "cognitio 1, fabrico 1");
+mods.thaumcraft.Aspects.set(<Mekanism:ConfigurationCard>, "cognitio 1, tutamen 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PortableTeleporter>, "metallum 16, instrumentum 4, iter 4, alienis 4, potentia 6");
+mods.thaumcraft.Aspects.set(<Mekanism:Flamethrower>, "metallum 14, telum 8, ignis 16, aer 4");
+
+# Machines
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:9>, "metallum 18, potentia 4, machina 8, tutamen 8, cognitio 8");
+mods.thaumcraft.Aspects.set(<Mekanism:GasTank:*>, "metallum 6, aer 4, vacuos 4");
+mods.thaumcraft.Aspects.set(<Mekanism:EnergyCube>, "metallum 19, potentia 4, machina 2");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock>, "metallum 9, permutatio 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:1>, "metallum 16, vacuos 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:2>, "metallum 14, motus 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:3>, "metallum 13, perditio 8, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:4>, "metallum 33, perfodio 16, potentia 16, machina 16, sensus 8");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:5>, "metallum 9, permutatio 8, potentia 8, machina 8");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:6>, "metallum 11, permutatio 12, potentia 12, machina 12");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:7>, "metallum 11, permutatio 16, potentia 16, machina 16, superbia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:8>, "metallum 9, ordo 2, vitreus 2, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:9>, "metallum 11, ordo 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:10>, "metallum 5, ignis 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:12>, "metallum 13, aqua 4, potentia 2, machina 2, motus 3, vacuos 2");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:13>, "metallum 8, vacuos 4, potentia 1, machina 2, tutamen 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:14>, "metallum 8, desidia 2 , potentia 8, machina 2");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:15>, "metallum 12, motus 2, cognitio 4, ordo 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2>, "metallum 13, motus 8, aqua 4, aer 4, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:1>, "metallum 12, perditio 8, potentia 2, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:2>, "metallum 17, fabrico 4, permutatio 4, potentia 2, machina 4, aqua 8");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:3>, "metallum 18, aqua 2, perditio 2, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:4>, "metallum 10, perditio 8, potentia 2, machina 4, aer 8");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:5>, "metallum 14, arbor 8, motus 2, potentia 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:6>, "metallum 11, ordo 8, potentia 4, machina 6");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:7>, "metallum 14, aqua 8, potentia 4, machina 6");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:8>, "metallum 14, vitreus 8, potentia 4, machina 6");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:9>, "metallum 12, motus 8, potentia 4, machina 4, terra 6");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:10>, "metallum 19, aer 4, aqua 4, terra 4, potentia 4, machina 8");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:12>, "metallum 16, permutatio 3, potentia 2, machina 2, aqua 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:13>, "metallum 19, machina 2, potentia 16, ignis 16, lux 16");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:14>, "metallum 20, permutatio 4, potentia 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock2:15>, "metallum 20, permutatio 4, potentia 4, lucrum 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock3>, "metallum 21, machina 8, iter 16, potentia 8, alienis 16, permutatio 16");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock3:1>, "metallum 10, machina 4, fabrico 4, potentia 4, lux 4, venenum 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock3:3>, "metallum 7, machina 4, cognitio 4, ordo 2, potentia 2, sensus 2");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock3:4>, "metallum 16, machina 4, ignis 6, vitreus 2, potentia 4");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock3:5>, "metallum 11, machina 4, fabrico 6, ordo 2, potentia 2");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock3:6>, "metallum 12, machina 4, ignis 4, ordo 2");
+
+# Generators
+mods.thaumcraft.Aspects.set(<MekanismGenerators:SolarPanel>, "metallum 2, lux 1, sensus 1");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator>, "metallum 10, ignis 8, machina 6, potentia 4");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:1>, "metallum 6, lux 2, sensus 2, machina 3, potentia 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:3>, "metallum 14, ignis 4, machina 8, potentia 8, aer 4");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:4>, "metallum 5, machina 4, potentia 3, terra 4");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:5>, "metallum 14, lux 7, sensus 7, machina 11, potentia 7");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:6>, "metallum 13, potentia 6, aer 8, machina 8, motus 6");
+
+# Multiblock Parts
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:7>, "metallum 7, ordo 3");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:8>, "metallum 9, ordo 2, potentia 6, motus 4, machina 6");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:9>, "metallum 17, ordo 2, machina 4, potentia 10");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:10>, "metallum 3, ordo 1, machina 1");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:11>, "metallum 3, ordo 1, machina 1, iter 1");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:12>, "metallum 3, ordo 1, machina 1, aer 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Generator:13>, "metallum 16, ordo 2, machina 4, vacuos 4, aqua 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Reactor>, "metallum 31, ordo 10, machina 10, cognitio 8, potentia 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Reactor:1>, "metallum 9, ordo 4, machina 4, potentia 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Reactor:3>, "metallum 21, ordo 8, machina 4, iter 4, potentia 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:Reactor:4>, "metallum 8, ordo 3, machina 4, cognitio 1, potentia 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:ReactorGlass>, "vitreus 4, metallum 3, ordo 2");
+mods.thaumcraft.Aspects.set(<MekanismGenerators:ReactorGlass:1>, "vitreus 4, metallum 3, ordo 2, permutatio 8, sensus 4");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:7>, "metallum 3, tenebrae 3, lux 3, alienis 4, machina 4");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:9>, "metallum 5, ordo 1, aqua 4");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:10>, "metallum 3, vitreus 1, aqua 1");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:11>, "metallum 10, ordo 2, aqua 8, iter 2");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:14>, "metallum 16, ignis 1, cognitio 4");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock:15>, "metallum 9, ignis 1, iter 2");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2>, "metallum 4, ignis 1");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:1>, "metallum 2, potentia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:2>, "metallum 2, potentia 1, iter 2");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:3>, "metallum 53, potentia 22, venenum 4");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:4>, "metallum 11, potentia 8, gelum 4, venenum 2, ignis 4, permutatio 8");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:5>, "metallum 10, aqua 1, ignis 6");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:6>, "metallum 8, ordo 2, aer 4");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:7>, "metallum 4, aqua 1");
+mods.thaumcraft.Aspects.set(<Mekanism:BasicBlock2:8>, "metallum 9, aqua 1, iter 2");
+mods.thaumcraft.Aspects.set(<Mekanism:MachineBlock:11>, "metallum 22, iter 10, alienis 10, lucrum 8, machina 12");
+
+
+# Pipes
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter>, "metallum 1, iter 1, potentia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:1>, "metallum 2, iter 2, potentia 2");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:10>, "metallum 3, iter 3, aer 3");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:11>, "metallum 4, iter 4, aer 4");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:12>, "metallum 1, iter 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:13>, "metallum 2, iter 2");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:14>, "metallum 3, iter 3");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:15>, "metallum 4, iter 4");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:16>, "metallum 3, iter 1, cognitio 1, desidia 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:17>, "metallum 3, iter 1, cognitio 1, lucrum 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:18>, "metallum 1, iter 1, ignis 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:19>, "metallum 2, iter 2, ignis 2");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:2>, "metallum 3, iter 3, potentia 3");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:3>, "metallum 4, iter 4, potentia 4");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:4>, "metallum 1, iter 1, aqua 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:5>, "metallum 2, iter 2, aqua 2");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:6>, "metallum 3, iter 3, aqua 3");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:7>, "metallum 4, iter 4, aqua 4");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:8>, "metallum 1, iter 1, aer 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:9>, "metallum 2, iter 2, aer 2");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:20>, "metallum 3, iter 3, ignis 3");
+mods.thaumcraft.Aspects.set(<Mekanism:PartTransmitter:21>, "metallum 4, iter 4, ignis 4");
+
+# Plastic
+for i in 0 to 16 {
+mods.thaumcraft.Aspects.set(<Mekanism:PlasticBlock>.definition.makeStack(i), "terra 5, humanus 5, sensus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:PlasticFence>.definition.makeStack(i), "terra 5, humanus 5, sensus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:SlickPlasticBlock>.definition.makeStack(i), "terra 5, humanus 5, sensus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:GlowPlasticBlock>.definition.makeStack(i), "terra 5, humanus 5, sensus 1, lux 4");
+mods.thaumcraft.Aspects.set(<Mekanism:ReinforcedPlasticBlock>.definition.makeStack(i), "terra 5, humanus 5, tutamen 4, sensus 1");
+mods.thaumcraft.Aspects.set(<Mekanism:GlowPanel>.definition.makeStack(i), "terra 5, humanus 5, lux 4, sensus 1");
+}
+
+
+
+
+
+
+
+
+
+
+### Tinker Construct ###
+# Contributor: daforsyth
+
+#Entities
+mods.thaumcraft.Aspects.addEntity("TConstruct.KingSlime", "superbia 5, limus 3");
+mods.thaumcraft.Aspects.addEntity("TConstruct.EdibleSlime", "messis 3, limus 2");
+
+# Heart Cans
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister:1>, "victus 2, sano 1");
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister:3>, "victus 4, superbia 1, sano 2");
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister:5>, "victus 8, lucrum 5, sano 4");
+
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister:2>, "metallum 3, sano 1, victus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister:4>, "victus 4, sano 4, metallum 3, lucrum 5");
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister:6>, "victus 8, sano 8, metallum 3, lucrum 10, superbia 1");
+
+# Slimeballs
+mods.thaumcraft.Aspects.set(<TConstruct:strangeFood>, "limus 2, fames 1");
+mods.thaumcraft.Aspects.set(<TConstruct:strangeFood:1>, "limus 1, victus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:36>, "limus 1, vinculum 1 ");
+
+# Modifier Stuff
+mods.thaumcraft.Aspects.set(<TConstruct:materials:1>, "limus 4, vitreus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:6>, "herba 13, praecantatio 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:7>, "ignis 16, praecantatio 4, vitreus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:8>, "mortuus 2, exanimis 2, venenum 2, infernus 1 ");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:17>, "limus 4, vitreus 3");
+mods.thaumcraft.Aspects.remove(<TConstruct:materials:26>, "bestia 18");
+
+# Nuggets
+mods.thaumcraft.Aspects.set(<TConstruct:materials:22>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:24>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:27>, "terra 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:28>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:29>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:30>, "metallum 1");
+
+mods.thaumcraft.Aspects.set(<TConstruct:oreBerries>, "metallum 1, messis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:oreBerries:1>, "metallum 1, messis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:oreBerries:2>, "metallum 1, messis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:oreBerries:3>, "metallum 1, messis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:oreBerries:4>, "metallum 1, messis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:oreBerries:5>, "cognitio 1, messis 1");
+
+# OreBerry Bushes
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.one:8>, "herba 4, metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.one:9>, "herba 4, metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.one:10>, "herba 4, metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.one:11>, "herba 4, metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.two:1>, "spiritus 4, herba 4");
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.two:8>, "herba 4, metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:ore.berries.two:9>, "spiritus 4, herba 4");
+
+# Blank Casts
+mods.thaumcraft.Aspects.set(<TConstruct:blankPattern>, "arbor 1");
+mods.thaumcraft.Aspects.set(<TConstruct:blankPattern:2>, "metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:blankPattern:1>, "metallum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:blankPattern:3>, "terra 2, aqua 2");
+
+# Misc
+mods.thaumcraft.Aspects.add(<TConstruct:rail.wood>, "iter 1");
+
+# Food
+mods.thaumcraft.Aspects.set(<TConstruct:jerky>, "fames 4, corpus 4, fabrico 2, gula 4");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:1>, "fames 3, corpus 4, fabrico 2, gula 3");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:2>, "fames 3, corpus 3, fabrico 2, gula 3");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:3>, "fames 3, corpus 3, fabrico 2, gula 3");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:4>, "fames 3, corpus 4, fabrico 2, gula 3");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:5>, "fames 1, corpus 4, exanimis 2");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:6>, "fames 2, limus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:jerky:7>, "fames 1, limus 1, victus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:strangeFood:2>, "fames 2, gula 1, corpus 1");
+
+# Parts
+mods.thaumcraft.Aspects.set(<TConstruct:bowstring>, "pannus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:bowstring:1>, "pannus 3, praecantatio 1 ");
+mods.thaumcraft.Aspects.set(<TConstruct:bowstring:2>, "pannus 3, ignis 1 ");
+
+# Tinker ingots
+mods.thaumcraft.Aspects.set(<TConstruct:materials:3>, "metallum 3, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:4>, "metallum 3, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:5>, "metallum 3, superbia 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:11>, "metallum 3, terra 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:12>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:14>, "metallum 3, machina 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:15>, "metallum 3, perfodio 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:18>, "terra 3, tenebrae 1");
+
+
+# Ores
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBrick:1>, "metallum 2, ignis 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBrick:2>, "metallum 2, ignis 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:GravelOre:4>, "metallum 2, terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:GravelOre:5>, "metallum 2, terra 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBrick:5>, "metallum 2, terra 2");
+
+# Travlers gear
+mods.thaumcraft.Aspects.set(<TConstruct:travelBoots>, "tutamen 3, motus 1, bestia 2, pannus 5");
+mods.thaumcraft.Aspects.set(<TConstruct:travelWings>, "tutamen 5, volatus 1, metallum 6, lucrum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:travelVest>, "tutamen 5, aqua 2, bestia 2, pannus 8");
+mods.thaumcraft.Aspects.set(<TConstruct:travelGoggles>, "tutamen 5, sensus 3, metallum 2, lucrum 2, pannus 2");
+mods.thaumcraft.Aspects.set(<TConstruct:travelBelt>, "pannus 9, bestia 4, vacuos 3, metallum 3");
+
+# Nuggets and dusts
+mods.thaumcraft.Aspects.set(<TConstruct:materials:31>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:32>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:33>, "metallum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:34>, "metallum 1, corpus 1, victus 1, bestia 1, fames 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:35>, "metallum 1, fames 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:38>, "metallum 2, perditio 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:39>, "metallum 2, perditio 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:40>, "metallum 2, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:41>, "metallum 2, perditio 1, superbia 1");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:42>, "metallum 2, perditio 1, machina 1");
+
+# Smeltery
+mods.thaumcraft.Aspects.set(<TConstruct:CastingChannel>, "terra 2, iter 2, ignis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBlock>, "terra 3, fabrico 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBlock:1>, "terra 1, ignis 1, iter 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBlock:2>, "terra 5, vacuos 4");
+mods.thaumcraft.Aspects.set(<TConstruct:LavaTank>, "terra 4, vacuos 4, vitreus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:LavaTankNether>, "terra 4, vacuos 4, vitreus 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether>, "terra 5, cognitio 1, inferus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:1>, "terra 5, vacuos 2, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery>, "terra 5, cognitio 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:1>, "terra 5, vacuos 2");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBlockNether>, "terra 3, fabrico 1, inferus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBlockNether:1>, "terra 1, ignis 1, iter 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SearedBlockNether:2>, "terra 5, vacuos 4, inferus 1");
+
+# Random
+mods.thaumcraft.Aspects.set(<TConstruct:trap.punji>, "herba 1, aer 1, aqua 1, telum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.sapling>, "herba 2, limus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.channel>, "limus 1, aqua 1, motus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:blood.channel>, "victus 1, aqua 1, motus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.pad>, "limus 2, motus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.leaves>, "limus 1, herba 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.stoneladder>, "terra 1");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.grass.tall>, "terra 1, herba 1, aer 1");
+mods.thaumcraft.Aspects.set(<TConstruct:liquid.slime>, "aqua 2, limus 2");
+mods.thaumcraft.Aspects.remove(<minecraft:paper>, "metallum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:materials>, "cognitio 3");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.gel>, "limus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.gel:2>, "limus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:heartCanister>, "metallum 2, vacuos 1");
+
+# Books
+mods.thaumcraft.Aspects.set(<TConstruct:manualBook>, "cognitio 3, instrumentum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:manualBook:1>, "cognitio 3, instrumentum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:manualBook:2>, "cognitio 3, fabrico 2");
+mods.thaumcraft.Aspects.set(<TConstruct:manualBook:3>, "cognitio 3, humanus 2");
+mods.thaumcraft.Aspects.set(<TConstruct:manualBook:4>, "cognitio 3, telum 2");
+
+
+# Brownstone
+mods.thaumcraft.Aspects.set(<TConstruct:SpeedBlock:*>, "terra 3, motus 1");
+
+# Glass
+mods.thaumcraft.Aspects.set(<TConstruct:GlassBlock.StainedClear:*>, "vitreus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:GlassBlock>, "vitreus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:GlassPaneClearStained:*>, "vitreus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:GlassPane>, "vitreus 1");
+
+# Seared Stuff
+mods.thaumcraft.Aspects.set(<TConstruct:materials:2>, "ignis 2, terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:materials:37>, "ignis 2, terra 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:2>, "ignis 5, terra 5");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:4>, "ignis 4, terra 4");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:5>, "ignis 4, terra 4, perdiditio 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:6>, "ignis 4, terra 4, ordo 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:8>, "ignis 4, terra 4, ordo 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:9>, "ignis 4, terra 4, ordo 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:7>, "ignis 4, terra 4, perdiditio 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:10>, "ignis 4, terra 4, ordo 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:11>, "ignis 4, terra 4, praecantatio 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:2>, "ignis 6, terra 3, infernus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:4>, "ignis 4, terra 3, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:5>, "ignis 4, terra 3, perdiditio 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:6>, "ignis 4, terra 3, ordo 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:7>, "ignis 4, terra 3, perdiditio 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:8>, "ignis 4, terra 3, ordo 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:9>, "ignis 4, terra 3, ordo 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:10>, "ignis 4, terra 3, ordo 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SmelteryNether:11>, "ignis 4, terra 3, praecantatio 1, infernus 1");
+
+# Slabs
+mods.thaumcraft.Aspects.set(<TConstruct:SearedSlab:*>, "terra 1");
+mods.thaumcraft.Aspects.set(<TConstruct:SpeedSlab:*>, "terra 1");
+
+# Blocks
+
+mods.thaumcraft.Aspects.add(<TConstruct:CraftedSoil:1>, "aqua 1");
+mods.thaumcraft.Aspects.set(<TConstruct:CraftedSoil:3>, "terra 1, exanimis 1, mortuus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:CraftedSoil:4>, "terra 1, lux 1, ignis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:CraftedSoil:5>, "terra 1, limus 1");
+mods.thaumcraft.Aspects.add(<TConstruct:CraftedSoil:6>, "infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.gel:1>, "limus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:GlueBlock>, "limus 4, vinculum 2 ");
+mods.thaumcraft.Aspects.set(<TConstruct:slime.grass>, "terra 1, limus 1, herba 1");
+mods.thaumcraft.Aspects.add(<TConstruct:slime.grass:5>, "terra 1, limus 1, herba 1");
+
+for i in 0 to 4 {
+mods.thaumcraft.Aspects.set(<TConstruct:Template>.definition.makeStack(i), "fabrico 1, terra 1, aqua 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Mold>.definition.makeStack(i), "fabrico 1, terra 1, ignis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Pattern>.definition.makeStack(i), "fabrico 1, arbor 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Cast>.definition.makeStack(i), "fabrico 1, metallum 1");
+}
+
+for i in 0 to 26 {
+mods.thaumcraft.Aspects.set(<TConstruct:woodPattern>.definition.makeStack(i), "fabrico 1, arbor 1");
+}
+
+
+# Clay, Ceramic & Metal Patterns
+for i in 0 to 28 {
+mods.thaumcraft.Aspects.set(<TConstruct:clayPattern>.definition.makeStack(i), "fabrico 1, terra 1, aqua 1");
+mods.thaumcraft.Aspects.set(<TConstruct:ceramicPattern>.definition.makeStack(i), "fabrico 1, terra 1, ignis 1");
+mods.thaumcraft.Aspects.set(<TConstruct:metalPattern>.definition.makeStack(i), "fabrico 1, metallum 1");
+}
+
+# Molten Buckets
+mods.thaumcraft.Aspects.set(<TConstruct:buckets>, "metallum 16, ignis 4, vacuos 1");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:1>, "metallum 12, ignis 4, vacuos 1, lucrum 10");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:2>, "metallum 12, ignis 4, vacuos 1, permutatio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:3>, "metallum 12, ignis 4, vacuos 1, vitreus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:4>, "metallum 12, ignis 4, vacuos 1, terra 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:5>, "metallum 12, ignis 4, vacuos 1, infernus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:6>, "metallum 12, ignis 4, vacuos 1, infernus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:7>, "metallum 12, ignis 4, vacuos 1, instrumentum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:8>, "metallum 12, ignis 4, vacuos 1, machina 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:9>, "metallum 12, ignis 4, vacuos 1, superbia 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:10>, "metallum 12, ignis 4, vacuos 1, perfodio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:11>, "metallum 8, ignis 4, vacuos 1, terra 4, tenebrenae 4");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:12>, "metallum 12, ignis 4, vacuos 1, ordo 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:13>, "metallum 8, ignis 4, vacuos 1, vitreus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:14>, "metallum 8, ignis 4, vacuos 1, terra 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:15>, "metallum 8, ignis 4, vacuos 1, lucrum 5, vitreus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:16>, "metallum 8, ignis 4, vacuos 1, victus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:17>, "metallum 12, ignis 4, vacuos 7");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:18>, "metallum 12, ignis 4, vacuos 1, ordo 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:19>, "metallum 12, ignis 4, vacuos 1, lucrum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:20>, "metallum 12, ignis 4, vacuos 1, lucrum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:21>, "metallum 12, ignis 4, vacuos 1, tutamen 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:22>, "metallum 12, ignis 4, vacuos 1, lucrum 10, potentia 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:23>, "metallum 8, aqua 4, vacuos 1, alienis 12, iter 12");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:24>, "metallum 8, aqua 4, vacuos 1, limus 4");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:25>, "metallum 8, ignis 4, vacuos 1, vinculum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:26>, "metallum 10, ignis 4, vacuos 1, bestia 6, corpus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:27>, "metallum 12, ignis 4, vacuos 1, lux 10, lucrum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:28>, "metallum 12, ignis 4, vacuos 1, permutatio 6, potentia 6, tutamen 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:29>, "metallum 12, ignis 4, vacuos 1, praecantatio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:buckets:30>, "metallum 12, ignis 4, vacuos 1, praecantatio 6, lucrum 6, alienis 6");
+
+# Liquid Blocks
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.alubrass>, "metallum 4, ignis 4, vacuos 1, machina 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.aluminum>, "metallum 4, ignis 4, vacuos 1, terra 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.manyullyn>, "metallum 4, ignis 4, vacuos 1, superbia 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.ardite>, "metallum 4, ignis 4, vacuos 1, infernus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.cobalt>, "metallum 4, ignis 4, vacuos 1, infernus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.silver>, "metallum 4, ignis 4, vacuos 1, lucrum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.lead>, "metallum 4, ignis 4, vacuos 1, ordo 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.bronze>, "metallum 4, ignis 4, vacuos 1, instrumentum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.tin>, "metallum 4, ignis 4, vacuos 1, vitreus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.copper>, "metallum 4, ignis 4, vacuos 1, permutatio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.alumite>, "metallum 4, ignis 4, vacuos 1, perfodio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.pigiron>, "metallum 4, ignis 4, vacuos 1, bestia 6, corpus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.nickel>, "metallum 4, ignis 4, vacuos 7");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.mithril>, "metallum 4, ignis 4, vacuos 1, praecantatio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.steel>, "metallum 4, ignis 4, vacuos 1, ordo 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.gold>, "metallum 4, ignis 4, vacuos 1, lucrum 10");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.iron>, "metallum 8, ignis 4, vacuos 1");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.invar>, "metallum 4, ignis 4, vacuos 1, tutamen 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.signalum>, "metallum 4, ignis 4, vacuos 1, permutatio 6, potentia 6, tutamen 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.lumium>, "metallum 4, ignis 4, vacuos 1, lux 10, lucrum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.enderium>, "metallum 4, ignis 4, vacuos 1, praecantatio 6, lucrum 6, alienis 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.electrum>, "metallum 4, ignis 4, vacuos 1, lucrum 10, potentia 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.shiny>, "metallum 4, ignis 4, vacuos 1, lucrum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.ender>, "aqua 4, vacuos 1, alienis 12, iter 12");
+mods.thaumcraft.Aspects.set(<TConstruct:liquid.glue>, "ignis 4, vacuos 1, vinculum 6");
+mods.thaumcraft.Aspects.set(<TConstruct:liquid.blood>, "ignis 4, vacuos 1, victus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:molten.emerald>, "ignis 4, vacuos 1, lucrum 5, vitreus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.obsidian>, "ignis 4, vacuos 1, terra 6");
+mods.thaumcraft.Aspects.set(<TConstruct:fluid.molten.glass>, "ignis 4, vacuos 1, vitreus 6");
+mods.thaumcraft.Aspects.set(<TConstruct:molten.stone>, "ignis 4, vacuos 1, terra 4, tenebrenae 4");
+
+# More Misc
+mods.thaumcraft.Aspects.set(<TConstruct:CraftingSlab:3>, "arbor 1");
+mods.thaumcraft.Aspects.set(<TConstruct:FurnaceSlab>, "ignis 1, perditio 1, terra 1");
+mods.thaumcraft.Aspects.set(<TConstruct:BattleSignBlock>, "telum 2, sensus 1, superbia 1");
+mods.thaumcraft.Aspects.set(<TConstruct:HeldItemBlock>, "ignis 2, instrumentum 2, invidia 1");
+
+# Decoration blocks
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock>, "metallum 20, infernus 7");
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock:1>, "metallum 20, infernus 7");
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock:2>, "metallum 20, superbia 7");
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock:6>, "metallum 20, terra 7");
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock:7>, "metallum 20, machina 7");
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock:8>, "metallum 20, perfodio 7");
+mods.thaumcraft.Aspects.set(<TConstruct:MetalBlock:10>, "alienis 12, iter 12, praecantatio 6");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick>, "terra 3, tenebrae 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:1>, "perditio 6, terra 5");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:2>, "terra 2, ignis 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:3>, "terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:4>, "metallum 4");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:5>, "metallum 3, lucrum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:6>, "terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:7>, "lucrum 4, vitreus 4");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:8>, "potentia 2, machina 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:9>, "mortuus 2, corpus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:10>, "limus 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:11>, "limus 2, fames 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:12>, "terra 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrick:13>, "terra 3, tenebrae 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy>, "terra 3, tenebrae 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:1>, "perditio 6, terra 5");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:2>, "terra 2, ignis 1, infernus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:3>, "terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:4>, "metallum 4");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:5>, "metallum 3, lucrum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:6>, "terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:7>, "lucrum 4, vitreus 4");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:8>, "potentia 2, machina 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:9>, "mortuus 2, corpus 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:10>, "limus 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:11>, "limus 2, fames 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:12>, "terra 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:13>, "terra 3, tenebrae 1");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:14>, "terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickfancy:15>, "terra 2");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal>, "metallum 20, perfodio 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:1>, "metallum 20, infernus 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:2>, "metallum 20, infernus 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:3>, "metallum 20, superbia 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:4>, "metallum 20, perfodio 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:5>, "metallum 20, infernus 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:6>, "metallum 20, infernus 7");
+mods.thaumcraft.Aspects.set(<TConstruct:decoration.multibrickmetal:7>, "metallum 20, superbia 7");
+
+
+# Last of stuff
+mods.thaumcraft.Aspects.set(<TConstruct:creativeModifier>, "instrumentum 32, superbia 32, lucrum 32");
+mods.thaumcraft.Aspects.set(<TConstruct:fletching>, "volatus 3, bestia 2");
+mods.thaumcraft.Aspects.set(<TConstruct:fletching:1>, "volatus 2, herba 3");
+mods.thaumcraft.Aspects.set(<TConstruct:fletching:2>, "volatus 2, limus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:fletching:3>, "volatus 2, limus 3");
+mods.thaumcraft.Aspects.set(<TConstruct:fletching:4>, "volatus 2, limus 1, herba 3");
+
+#Tools
+mods.thaumcraft.Aspects.set(<TConstruct:pickaxe>, "perfodio 3");
+mods.thaumcraft.Aspects.set(<TConstruct:shovel>, "instrumentum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:hatchet>, "instrumentum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:broadsword>, "telum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:longsword>, "telum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:rapier>, "telum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:dagger>, "telum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:frypan>, "telum 2");
+mods.thaumcraft.Aspects.set(<TConstruct:cutlass>, "telum 3");
+mods.thaumcraft.Aspects.set(<TConstruct:battlesign>, "telum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:mattock>, "instrumentum 2, meto 1");
+mods.thaumcraft.Aspects.set(<TConstruct:chisel>, "instrumentum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:lumberaxe>, "instrumentum 8");
+mods.thaumcraft.Aspects.set(<TConstruct:cleaver>, "telum 8");
+mods.thaumcraft.Aspects.set(<TConstruct:scythe>, "telum 4, meto 4");
+mods.thaumcraft.Aspects.set(<TConstruct:hammer>, "perfodio 8");
+mods.thaumcraft.Aspects.set(<TConstruct:excavator>, "instrumentum 8");
+mods.thaumcraft.Aspects.set(<TConstruct:battleaxe>, "telum 8");
+mods.thaumcraft.Aspects.set(<TConstruct:Shuriken>, "telum 1, aer 1");
+mods.thaumcraft.Aspects.set(<TConstruct:ThrowingKnife>, "telum 1, aer 1");
+mods.thaumcraft.Aspects.set(<TConstruct:Javelin>, "telum 3, aer 1");
+mods.thaumcraft.Aspects.set(<TConstruct:ShortBow>, "telum 3, aer 1");
+mods.thaumcraft.Aspects.set(<TConstruct:LongBow>, "telum 4, aer 2");
+mods.thaumcraft.Aspects.set(<TConstruct:Crossbow>, "telum 4, machina 2");
+mods.thaumcraft.Aspects.set(<TConstruct:ArrowAmmo>, "telum 1");
+mods.thaumcraft.Aspects.set(<TConstruct:BoltAmmo>, "telum 1");
+
+# Parts
+mods.thaumcraft.Aspects.set(<TConstruct:toolRod:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:toolShard:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:pickaxeHead:*>, "perfodio 0");
+mods.thaumcraft.Aspects.set(<TConstruct:shovelHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:hatchetHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:binding:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:toughBinding:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:toughRod:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:heavyPlate:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:swordBlade:*>, "telum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:wideGuard:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:handGuard:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:crossbar:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:knifeBlade:*>, "telum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:fullGuard:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:frypanHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:signHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:chiselHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:scytheBlade:*>, "meto 0");
+mods.thaumcraft.Aspects.set(<TConstruct:broadAxeHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:excavatorHead:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:BoltPart:*>, "telum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:CrossbowLimbPart:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:BowLimbPart:*>, "instrumentum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:ShurikenPart:*>, "telum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:arrowhead:*>, "telum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:hammerHead:*>, "perfodio 0");
+mods.thaumcraft.Aspects.set(<TConstruct:largeSwordBlade:*>, "telum 0");
+mods.thaumcraft.Aspects.set(<TConstruct:CrossbowBodyPart:*>, "instrumentum 0");
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
In this branch I've added two files that you might want to just copy and paste into the main "TC4 - Aspects.zs)

=========================================================================
First I created: "TC4 - Aspects - BinniesMods.zs"
I did not write this script within TC4 - Aspects.zs, due to the formatting of that script being by mod names alphabetically. I opted to just put these mods in a separate file as they are all more or less heavily related to each other. If you want to use this script you're free to do as you please.

The following mods are given Thaumcraft Aspects:
- Forestry
- Binnies Core
- Extra Trees
- Extra Bees
- Magic Bees
- Genetics
- Botany
=========================================================================
Next I created: "TC4 - Aspects - LostScripts"
This is just a collection of scripts that were removed. I'm not sure why they've been removed, though I assume it was for loading time. Regardless I put them back in the event you still want to use them. I feel like these mods are significant receivers for thaum aspects.

The following mods given Thaumcraft Aspects:
- Blood Magic
- Electrobobs Wizardry
- Mekanism
- Tinkers Construct


